### PR TITLE
Fix "artifact not found for target 'mocap4face'" error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,13 +12,13 @@ let package = Package(
     products: [
         .library(
             name: "mocap4face",
-            targets: ["mocap4face"]),
+            targets: ["Mocap4Face"]),
     ],
     dependencies: [
     ],
     targets: [
         .binaryTarget(
-                    name: "mocap4face",
+                    name: "Mocap4Face",
                     path: "frameworks/Mocap4Face.xcframework"
                 )
     ]


### PR DESCRIPTION
## Issue

- I got "artifact not found for target 'mocap4face'" error when I tried to load `mocap4face` Swift Package by Xcode 13.3
    <img width="315" alt="mocap4face_err" src="https://user-images.githubusercontent.com/1047810/158349366-a31a6f26-5b9b-4b4a-8ad3-1fe9144f996f.png">
    - The target name should be exactly the same as the framework name (case sensitive)

## Changes

- Change the target name from `mocap4face` to `Mocap4Face` to match the framework name
